### PR TITLE
chore: update golangci-lint to 1.50.0

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -46,5 +46,5 @@ deps:
 	echo
 
 lint:
-	curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(GOBIN) v1.46.2
+	curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(GOBIN) v1.50.0
 	$(GOBIN)/golangci-lint run ./...


### PR DESCRIPTION
closes #36

*Issue #, if available:*

*Description of changes:*
update golangci-lint to 1.50.0

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
