### PR TITLE
fix: return pointer to LinkNotFoundError, matching other uses

### DIFF
--- a/internal/cniutil.go
+++ b/internal/cniutil.go
@@ -81,7 +81,7 @@ func VMTapPair(
 			"expected to find at most 1 interface in sandbox %q, but instead found %d",
 			vmID, len(vmIfaces))
 	} else if len(vmIfaces) == 0 {
-		return nil, nil, LinkNotFoundError{device: fmt.Sprintf("pseudo-device for %s", vmID)}
+		return nil, nil, &LinkNotFoundError{device: fmt.Sprintf("pseudo-device for %s", vmID)}
 	}
 
 	vmIface = vmIfaces[0]
@@ -97,7 +97,7 @@ func VMTapPair(
 			"expected to find at most 1 interface with name %q, but instead found %d",
 			tapName, len(tapIfaces))
 	} else if len(tapIfaces) == 0 {
-		return nil, nil, LinkNotFoundError{device: tapName}
+		return nil, nil, &LinkNotFoundError{device: tapName}
 	}
 
 	tapIface = tapIfaces[0]


### PR DESCRIPTION
*Description of changes:*

I noticed that a LinkNotFoundError was being returned as an error when calling del(), and the error typeswitch wasn't catching it because it's looking for a pointer. All other uses of LinkNotFoundError are returning pointers to it, so I made the return in VMTapPair() consistent with the rest.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
