### PR TITLE
Update GitHub actions workflow packages

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -23,7 +23,7 @@ jobs:
     name: Go ${{ matrix.go }}
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           # By default, the checkout action only fetches the last commit,
           # but we want to run DCO check against all commit messages.
@@ -36,7 +36,7 @@ jobs:
           # So we need to fetch 21 commits (including the merge commit)
           # to have 20 actual commits from a pull request.
           fetch-depth: 21
-      - uses: actions/setup-go@v1
+      - uses: actions/setup-go@v3
         with:
           go-version: ${{ matrix.go }}
       - run: make deps


### PR DESCRIPTION
Signed-off-by: Austin Vazquez <macedonv@amazon.com>

*Issue #, if available:*

*Description of changes:*
Updates actions/checkout and actions/setup-go from v2 to v3.

https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
