### PR TITLE
Add Go 1.21 support to CI

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -17,7 +17,7 @@ jobs:
 
     strategy:
       matrix:
-        go: ['1.17', '1.18', '1.19']
+        go: ['1.21', '1.22']
       # Build all variants regardless of failures
       fail-fast: false
     name: Go ${{ matrix.go }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -14,7 +14,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v4
         with:
-          go-version: 1.18
+          go-version: 1.21
 
       - name: Get dependencies
         run: make deps

--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@ GOMOD := $(shell go env GOMOD)
 GOSUM := $(GOMOD:.mod=.sum)
 GOBIN := $(abspath ./bin)
 
-GOLANGCI_LINT_VERSION?=v1.53.3
+GOLANGCI_LINT_VERSION?=v1.56.2
 
 # Set this to override the directory in which the tc-redirect-tap plugin is
 # installed by the "install" target


### PR DESCRIPTION
*Issue #, if available:*
N/A

*Description of changes:*
Go 1.21 and 1.22 have been released. Adding it to CI matrix for testing.

Updates golangci-lint from v1.53.3 to v1.56.2 for Go 1.21 support.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
