### PR TITLE
FIX: broken Release GHA

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -24,8 +24,8 @@ jobs:
 
       - name: Build
         run: |
-          GOOS=linux GOARCH=amd64 go build -o bin/tc-redirect-tap-amd64 ./cmd/tc-redirect-tap
-          GOOS=linux GOARCH=arm64 go build -o bin/tc-redirect-tap-arm64 ./cmd/tc-redirect-tap
+          CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -o bin/tc-redirect-tap-amd64 ./cmd/tc-redirect-tap
+          CGO_ENABLED=0 GOOS=linux GOARCH=arm64 go build -o bin/tc-redirect-tap-arm64 ./cmd/tc-redirect-tap
 
       - name: Sign
         run: |

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,7 +1,7 @@
 name: Release
 
 on:
-  create:
+  push:
     tags:
       - 'v*'
 

--- a/Makefile
+++ b/Makefile
@@ -29,7 +29,7 @@ CNI_BIN_ROOT?=/opt/cni/bin
 all: tc-redirect-tap
 
 tc-redirect-tap: $(SOURCES) $(GOMOD) $(GOSUM)
-	go build -o tc-redirect-tap $(CURDIR)/cmd/tc-redirect-tap
+	CGO_ENABLED=0 go build -o tc-redirect-tap $(CURDIR)/cmd/tc-redirect-tap
 
 .PHONY: install
 install: tc-redirect-tap


### PR DESCRIPTION
*Description of changes:*

This fixes the release action that has need failing. Will require a tag (as originally intended).  Would it be possible to cut on official release with this working?  
Thanks!!!

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.


Additionally, we noticed that most (all) CNI plugins are statically linked.  This disables CGO to align with that standard