### PR TITLE
Fix plugin supported CNI versions

### DIFF
--- a/cmd/tc-redirect-tap/main.go
+++ b/cmd/tc-redirect-tap/main.go
@@ -40,8 +40,7 @@ func main() {
 			Check: check,
 			Del:   del,
 		},
-		// support CNI versions that support plugin chaining
-		version.PluginSupports("0.3.0", "0.3.1", "0.4.0", version.Current()),
+		version.PluginSupports(internal.SupportedVersions()...),
 		buildversion.BuildString("tc-redirect-tap"),
 	)
 }

--- a/internal/supported_versions.go
+++ b/internal/supported_versions.go
@@ -1,0 +1,32 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//	http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package internal
+
+import (
+	"github.com/containernetworking/cni/pkg/version"
+)
+
+func SupportedVersions() []string {
+	// support CNI versions that support plugin chaining
+	supported := []string{}
+	unsupported := map[string]bool{"0.1.0": true, "0.2.0": true}
+
+	for _, v := range version.All.SupportedVersions() {
+		if _, ok := unsupported[v]; !ok {
+			supported = append(supported, v)
+		}
+	}
+
+	return supported
+}

--- a/internal/supported_versions_test.go
+++ b/internal/supported_versions_test.go
@@ -1,0 +1,43 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//	http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package internal
+
+import (
+	"testing"
+)
+
+func TestSupportedVersions(t *testing.T) {
+	supportedVersions := SupportedVersions()
+
+	contains := func(arr []string, find string) bool {
+		for _, i := range arr {
+			if i == find {
+				return true
+			}
+		}
+		return false
+	}
+
+	for _, v := range []string{"0.1.0", "0.2.0"} {
+		if contains(supportedVersions, v) {
+			t.Errorf("expected %s to not be a supported version", v)
+		}
+	}
+
+	for _, v := range []string{"0.3.0", "0.3.1", "0.4.0", "1.0.0", "1.1.0"} {
+		if !contains(supportedVersions, v) {
+			t.Errorf("expected %s to be a supported version", v)
+		}
+	}
+}


### PR DESCRIPTION
*Issue #, if available:*
#98 

Before this change, plugin version 1.0.0 was not being reported as supported after version 1.1.0 became the current version.

*Description of changes:*
This change reworks the supported versions logic to use CNI `version.All` variable instead of `version.CurrentVersion` function whose value changes across plugin versions.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
