### PR TITLE
Return correct CNI version string

### DIFF
--- a/cmd/tc-redirect-tap/main_test.go
+++ b/cmd/tc-redirect-tap/main_test.go
@@ -195,13 +195,14 @@ func TestAddFailsCreateTapErr(t *testing.T) {
 
 func TestGetCurrentResult(t *testing.T) {
 	expectedResult := defaultTestPlugin().currentResult
+	expectedCNIVersion := "0.3.1"
 
 	netConf := &types.NetConf{
-		CNIVersion: "0.3.1",
+		CNIVersion: expectedCNIVersion,
 		Name:       "my-lil-network",
 		Type:       "my-lil-plugin",
 		RawPrevResult: map[string]interface{}{
-			"cniVersion": "0.3.1",
+			"cniVersion": expectedCNIVersion,
 			"interfaces": expectedResult.Interfaces,
 			"ips":        expectedResult.IPs,
 			"routes":     expectedResult.Routes,
@@ -216,10 +217,11 @@ func TestGetCurrentResult(t *testing.T) {
 		StdinData: rawPrevResultBytes,
 	}
 
-	actualResult, err := getCurrentResult(cmdArgs)
+	actualResult, actualCNIVersion, err := getCurrentResult(cmdArgs)
 	require.NoError(t, err, "failed to get current result from mock net conf")
 
 	assert.Equal(t, expectedResult, actualResult)
+	assert.Equal(t, expectedCNIVersion, actualCNIVersion)
 }
 
 func TestDel(t *testing.T) {


### PR DESCRIPTION
*Issue #, if available:*
Related to #98 

*Description of changes:*

Prior to this commit, we were using the output of a result to return a CNI version. This would always be the latest supported version returned by the CNI library. This meant that, regardless of the CNI version used in a user's conflist, it would always report back that the latest version was being used, which is both incorrect behavior and breaks workflows where the latest version was not recognized as a valid version.

This change fixes this behavior and returns the same CNI version specified in the conflist, which mirrors the behavior of other CNI plugins (e.g. [ptp](https://github.com/containernetworking/plugins/blob/ba8bc7d0c70ab99d1a484982b437be92dc509e56/plugins/main/ptp/ptp.go#L183), [bridge](https://github.com/containernetworking/plugins/blob/ba8bc7d0c70ab99d1a484982b437be92dc509e56/plugins/main/bridge/bridge.go#L519))

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
