### PR TITLE
Bump min Go version to 1.23

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -17,7 +17,7 @@ jobs:
 
     strategy:
       matrix:
-        go: ['1.21', '1.22']
+        go: ['1.23', '1.24']
       # Build all variants regardless of failures
       fail-fast: false
     name: Go ${{ matrix.go }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -14,7 +14,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: 1.21
+          go-version: 1.23
 
       - name: Get dependencies
         run: make deps

--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@ GOMOD := $(shell go env GOMOD)
 GOSUM := $(GOMOD:.mod=.sum)
 GOBIN := $(abspath ./bin)
 
-GOLANGCI_LINT_VERSION?=v1.56.2
+GOLANGCI_LINT_VERSION?=v1.64.7
 
 # Set this to override the directory in which the tc-redirect-tap plugin is
 # installed by the "install" target

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,8 @@
 module github.com/awslabs/tc-redirect-tap
 
-go 1.21
+go 1.23.0
+
+toolchain go1.23.7
 
 require (
 	github.com/containernetworking/cni v1.2.3


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
This change bumps the min Go version to Go 1.23 to unblock dependabot PRs.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
